### PR TITLE
feat: retry step for platforms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -191,7 +191,11 @@ jobs:
           args: yarn
 
       - name: test ${{ matrix.platform }}
-        run: bash .github/scripts/test-project.sh platforms ${{ matrix.platform }}
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: bash .github/scripts/test-project.sh platforms ${{ matrix.platform }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}

--- a/platforms/heroku/run.sh
+++ b/platforms/heroku/run.sh
@@ -2,8 +2,6 @@
 
 set -eux
 
-exit 1
-
 sudo snap install heroku --classic
 yarn install
 yarn prisma2 generate

--- a/platforms/heroku/run.sh
+++ b/platforms/heroku/run.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+exit 1
+
 sudo snap install heroku --classic
 yarn install
 yarn prisma2 generate


### PR DESCRIPTION
Another take on improving https://github.com/prisma/e2e-tests/issues/415

This PR uses https://github.com/marketplace/actions/retry-step to retry any platform step that fails. 

This is how a failure looks like (I forced a failure with `exit 1`): 

Three instances of this error, not pretty but the retry logic works

![image](https://user-images.githubusercontent.com/746482/86145079-1e480d80-bb14-11ea-9f8d-4774cee7c984.png)
