### PR TITLE
feat: customize emoji on the last attempt, approach 2 (simpler)

### DIFF
--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -101,7 +101,7 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/patch-d
 	version="$(cat .github/prisma-version.txt)"
 	sha="$(git rev-parse HEAD | cut -c -7)"
 
-	emoji=":x:"
+	emoji=":warning:"
 	if [ $code -eq 0 ]; then
 		emoji=":white_check_mark:"
 	fi
@@ -112,7 +112,7 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/patch-d
 	if [ $code -ne 0 ]; then
 		export webhook="$SLACK_WEBHOOK_URL_FAILING"
 		echo "notifying failing slack channel"
-		node .github/slack/notify.js "prisma@$version: :x: $workflow_link failed (via $commit_link)"
+		node .github/slack/notify.js "prisma@$version: ${emoji} $workflow_link failed (via $commit_link)"
 	fi
 fi
 

--- a/.github/slack/notify-failure.sh
+++ b/.github/slack/notify-failure.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+dir=$1
+project=$2
+set +u
+matrix=$3
+set -u
+
+if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/patch-dev" ] || [ "$GITHUB_REF" = "refs/heads/latest" ]; then
+	(cd .github/slack/ && yarn install --silent)
+
+	branch="${GITHUB_REF##*/}"
+	sha="$(git rev-parse HEAD | cut -c -7)"
+	short_sha="$(echo "$sha" | cut -c -7)"
+	commit_link="\`<https://github.com/prisma/prisma-e2e-tests/commit/$sha|$branch@$short_sha>\`"
+	workflow_link="<https://github.com/prisma/prisma-e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
+
+	export webhook="$SLACK_WEBHOOK_URL"
+	version="$(cat .github/prisma-version.txt)"
+	sha="$(git rev-parse HEAD | cut -c -7)"
+
+	emoji=":x:"
+	
+	export webhook="$SLACK_WEBHOOK_URL_FAILING"
+	echo "notifying failing slack channel"
+	node .github/slack/notify.js "prisma@$version: ${emoji} $workflow_link failed (via $commit_link)"
+fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,9 @@ jobs:
           version: 12
 
       - name: test on ${{ matrix.os }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -65,6 +67,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh generic basic ${{ matrix.os }}
 
   node:
     runs-on: ubuntu-latest
@@ -87,7 +93,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: test on node ${{ matrix.node }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -96,6 +104,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh generic basic "node ${{ matrix.node }}"
 
   binaries:
     strategy:
@@ -111,7 +123,9 @@ jobs:
           version: 12
 
       - name: test on ${{ matrix.os }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -120,6 +134,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           OS: ${{ matrix.os }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh binaries pkg ${{ matrix.os }}
 
   packagers:
     runs-on: ubuntu-latest
@@ -141,7 +159,9 @@ jobs:
           node-version: 10
 
       - name: packager ${{ matrix.packager }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -152,6 +172,10 @@ jobs:
           PACKAGERS_NPM_PG_URL: ${{ secrets.PACKAGERS_NPM_PG_URL }}
           PACKAGERS_YARN_PG_URL: ${{ secrets.PACKAGERS_YARN_PG_URL }}
           PACKAGERS_YARN_WORKSPACES_PG_URL: ${{ secrets.PACKAGERS_YARN_WORKSPACES_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh packagers ${{ matrix.packager }}
 
   frameworks:
     runs-on: ubuntu-latest
@@ -173,7 +197,9 @@ jobs:
           node-version: 10
 
       - name: framework ${{ matrix.framework }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -184,6 +210,10 @@ jobs:
           FRAMEWORK_NEXTJS_PG_URL: ${{ secrets.FRAMEWORK_NEXTJS_PG_URL }}
           FRAMEWORK_NESTJS_PG_URL: ${{ secrets.FRAMEWORK_NESTJS_PG_URL }}
           FRAMEWORK_NEXUS_PG_URL: ${{ secrets.FRAMEWORK_NEXUS_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh frameworks ${{ matrix.framework }}
 
   platforms:
     runs-on: ubuntu-latest
@@ -219,7 +249,9 @@ jobs:
           args: yarn
 
       - name: test ${{ matrix.platform }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -261,6 +293,10 @@ jobs:
           FIREBASE_FUNCTIONS_PG_URL: ${{ secrets.FIREBASE_FUNCTIONS_PG_URL }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
+
   bundlers:
     runs-on: ubuntu-latest
 
@@ -282,7 +318,9 @@ jobs:
           node-version: 10
 
       - name: test ${{ matrix.bundler }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -293,6 +331,10 @@ jobs:
           WEBPACK_PG_URL: ${{ secrets.WEBPACK_PG_URL }}
           PARCEL_PG_URL: ${{ secrets.PARCEL_PG_URL }}
           ROLLUP_PG_URL: ${{ secrets.ROLLUP_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh bundlers ${{ matrix.bundler }}
 
   libraries:
     runs-on: ubuntu-latest
@@ -315,7 +357,9 @@ jobs:
           node-version: 10
 
       - name: test ${{ matrix.library }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -326,6 +370,10 @@ jobs:
           LIBRARY_EXPRESS_PG_URL: ${{ secrets.LIBRARY_EXPRESS_PG_URL }}
           LIBRARY_APOLLO_SERVER_PG_URL: ${{ secrets.LIBRARY_APOLLO_SERVER_PG_URL }}
           LIBRARY_TYPE_GRAPHQL_PG_URL: ${{ secrets.LIBRARY_TYPE_GRAPHQL_PG_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh libraries ${{ matrix.library }}
 
   databases:
     runs-on: ubuntu-latest
@@ -352,7 +400,9 @@ jobs:
           node-version: 12
 
       - name: test ${{ matrix.database }}
+        id: run-test
         uses: nick-invision/retry@v1
+        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -363,3 +413,7 @@ jobs:
           DATABASE_DO_PG_BOUNCER_URL: ${{ secrets.DATABASE_DO_PG_BOUNCER_URL }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           DATABASE_HEROKU_PGBOUNCER_URL: ${{ secrets.DATABASE_HEROKU_PGBOUNCER_URL }}
+
+      - name: notify-slack
+        if: ${{ steps.run-test.outcome != 'success' }}
+        run: sh .github/slack/notify-failure.sh databases ${{ matrix.database }}


### PR DESCRIPTION
Fixes https://github.com/prisma/e2e-tests/issues/505

This is a simpler version of https://github.com/prisma/e2e-tests/pull/560 and has one small limitation: 

In this approach, we can't granularly control the last failure message, so max attempts 3 can be represented as

- In the simpler approach (this PR): :warning:, :warning:, :warning:, ❌ (We don't know in the last attempt that is indeed the last attempt 

- In the stateful approach (https://github.com/prisma/e2e-tests/pull/560): :warning:, :warning:, ❌ (We know before the last attempt is tried that it will be the last attempt but after all attempts have failed we can customize the message)

I tested this out by creating a fake test that always fails and it looks like this

![image](https://user-images.githubusercontent.com/746482/87660665-111a5800-c77d-11ea-9c3c-640190d65cc9.png)
