### PR TITLE
fix: slack message

### DIFF
--- a/.github/scripts/slack-workflow-status.sh
+++ b/.github/scripts/slack-workflow-status.sh
@@ -13,7 +13,7 @@ sha="$(git rev-parse HEAD)"
 short_sha="$(echo "$sha" | cut -c -7)"
 message="$(git log -1 --pretty=%B | head -n 1)"
 
-commit_link="\`<https://github.com/prisma/prisma-e2e-tests/commit/$sha|$branch@$short_sha>\`"
-workflow_link="<https://github.com/prisma/prisma-e2e-tests/actions/runs/$GITHUB_RUN_ID|$message>"
+commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
+workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$message>"
 
 node .github/slack/notify.js "prisma@$version: $emoji $workflow_link (via $commit_link)"

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -94,8 +94,8 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/patch-d
 	branch="${GITHUB_REF##*/}"
 	sha="$(git rev-parse HEAD | cut -c -7)"
 	short_sha="$(echo "$sha" | cut -c -7)"
-	commit_link="\`<https://github.com/prisma/prisma-e2e-tests/commit/$sha|$branch@$short_sha>\`"
-	workflow_link="<https://github.com/prisma/prisma-e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
+	commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
+	workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
 
 	export webhook="$SLACK_WEBHOOK_URL"
 	version="$(cat .github/prisma-version.txt)"

--- a/.github/slack/notify-failure.sh
+++ b/.github/slack/notify-failure.sh
@@ -14,8 +14,8 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/patch-d
 	branch="${GITHUB_REF##*/}"
 	sha="$(git rev-parse HEAD | cut -c -7)"
 	short_sha="$(echo "$sha" | cut -c -7)"
-	commit_link="\`<https://github.com/prisma/prisma-e2e-tests/commit/$sha|$branch@$short_sha>\`"
-	workflow_link="<https://github.com/prisma/prisma-e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
+	commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
+	workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
 
 	export webhook="$SLACK_WEBHOOK_URL"
 	version="$(cat .github/prisma-version.txt)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,14 +62,13 @@ jobs:
       - name: test on ${{ matrix.os }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh generic basic ${{ matrix.os }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh generic basic ${{ matrix.os }}
 
   node:
@@ -99,14 +98,13 @@ jobs:
       - name: test on node ${{ matrix.node }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh generic basic "node ${{ matrix.node }}"
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh generic basic "node ${{ matrix.node }}"
 
   binaries:
@@ -129,14 +127,13 @@ jobs:
       - name: test on ${{ matrix.os }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh binaries pkg ${{ matrix.os }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh binaries pkg ${{ matrix.os }}
 
   packagers:
@@ -168,14 +165,13 @@ jobs:
       - name: packager ${{ matrix.packager }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh packagers ${{ matrix.packager }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh packagers ${{ matrix.packager }}
 
   frameworks:
@@ -207,14 +203,13 @@ jobs:
       - name: framework ${{ matrix.framework }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh frameworks ${{ matrix.framework }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh frameworks ${{ matrix.framework }}
 
   platforms:
@@ -289,14 +284,13 @@ jobs:
       - name: test ${{ matrix.platform }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: bash .github/scripts/test-project.sh platforms ${{ matrix.platform }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
 
   bundlers:
@@ -328,14 +322,13 @@ jobs:
       - name: test ${{ matrix.bundler }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh bundlers ${{ matrix.bundler }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh bundlers ${{ matrix.bundler }}
 
   libraries:
@@ -367,14 +360,13 @@ jobs:
       - name: test ${{ matrix.library }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh libraries ${{ matrix.library }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh libraries ${{ matrix.library }}
 
   databases:
@@ -410,12 +402,11 @@ jobs:
       - name: test ${{ matrix.database }}
         id: run-test
         uses: nick-invision/retry@v1
-        continue-on-error: true
         with:
           timeout_minutes: 10
           max_attempts: 3
           command: bash .github/scripts/test-project.sh databases ${{ matrix.database }}
 
       - name: notify-slack
-        if: ${{ steps.run-test.outcome != 'success' }}
+        if: failure()
         run: sh .github/slack/notify-failure.sh databases ${{ matrix.database }}


### PR DESCRIPTION
Use of continue on error in https://github.com/prisma/e2e-tests/pull/561
makes the global workflow notification not trigger.

This PR replaces it with failed(). We ~still need to verify if~ verified that `failed()` is
catched twice once by the next step and once by the global slack
notification step.

I couldn't find this in GH actions docs.

Tested it and it works ✅ 

![image](https://user-images.githubusercontent.com/746482/87758650-78daac80-c82a-11ea-9837-dccede038691.png)

![image](https://user-images.githubusercontent.com/746482/87758685-8abc4f80-c82a-11ea-9e67-e2f8f5b5caa6.png)
